### PR TITLE
Merge cout transformation rules into one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/RegularExpressions.Transformer.CppToJava/issues/1
-Your prepared branch: issue-1-80ee48f3
-Your prepared working directory: /tmp/gh-issue-solver-1757822191789
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/RegularExpressions.Transformer.CppToJava/issues/1
+Your prepared branch: issue-1-80ee48f3
+Your prepared working directory: /tmp/gh-issue-solver-1757822191789
+
+Proceed.

--- a/RegularExpressions.Transformer.CppToJava/CppToJavaTransformer.cs
+++ b/RegularExpressions.Transformer.CppToJava/CppToJavaTransformer.cs
@@ -41,12 +41,9 @@ namespace Platform.RegularExpressions.Transformer.CppToJava
             // str.pop_back()
             // str = str.substring(0, str.length() - 1)
             (new Regex(@"(?<variable>[_a-zA-Z0-9]+)\.pop_back\(\)"), "${variable} = ${variable}.substring(0, ${variable}.length() - 1)", null, 0),
-            // cout << "text";
-            // System.out.print("text");
-            (new Regex(@"cout << ""(?<text>[^""\r\n]+)"";"), "System.out.print(\"${text}\");", null, 0),
-            // cout << text;
-            // System.out.print(text);
-            (new Regex(@"cout << (?<variable>[_a-zA-Z0-9]+);"), "System.out.print(${variable});", null, 0),
+            // cout << "text"; or cout << variable;
+            // System.out.print("text"); or System.out.print(variable);
+            (new Regex(@"cout << (?<content>(?:""[^""\r\n]+"")|(?:[_a-zA-Z0-9]+));"), "System.out.print(${content});", null, 0),
             // int main() { ... getline 
             // int main() { Scanner input = new Scanner(System.in); ... getline 
             (new Regex(@"(?<method>\r?\n[ \t]*[a-zA-Z ]+ [a-zA-Z]+[ \t]*\([^\)\r\n]*\)([^\{]|\n)+{[\r\n]*)(?<indent>[ \t]+)(?<end>((?!(Scanner input = new Scanner\(System\.in\);|\k<indent>[^\r\n]+\r?\n[ \t]+}))(.|\n))+?getline\(cin)"), "${method}${indent}Scanner input = new Scanner(System.in);" + Environment.NewLine + "${indent}${end}", null, 0),

--- a/experiments/CoutMergeTest/CoutMergeTest.csproj
+++ b/experiments/CoutMergeTest/CoutMergeTest.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/experiments/CoutMergeTest/Program.cs
+++ b/experiments/CoutMergeTest/Program.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+class Program 
+{
+    static void Main() 
+    {
+        // Test cases
+        string[] testCases = {
+            "cout << \"Hello World\";",
+            "cout << variable;", 
+            "cout << \"text with spaces\";",
+            "cout << myVar;",
+            "cout << \"multi word text\";",
+            "cout << anotherVariable;"
+        };
+        
+        // Original separate rules
+        var rule1 = new Regex(@"cout << ""(?<text>[^""\r\n]+)"";");
+        var rule2 = new Regex(@"cout << (?<variable>[_a-zA-Z0-9]+);");
+        
+        // Proposed merged rule - handles both quoted strings and variables
+        var mergedRule = new Regex(@"cout << (?:""(?<text>[^""\r\n]+)""|(?<variable>[_a-zA-Z0-9]+));");
+        
+        Console.WriteLine("Testing original rules vs merged rule:");
+        Console.WriteLine("=====================================");
+        
+        foreach (string test in testCases) 
+        {
+            Console.WriteLine($"Input: {test}");
+            
+            // Test original rules
+            string result1 = rule1.Replace(test, "System.out.print(\"${text}\");");
+            string result2 = rule2.Replace(result1, "System.out.print(${variable});");
+            Console.WriteLine($"Original: {result2}");
+            
+            // Test merged rule
+            string mergedResult = mergedRule.Replace(test, m => {
+                if (m.Groups["text"].Success)
+                    return $"System.out.print(\"{m.Groups["text"].Value}\");";
+                else
+                    return $"System.out.print({m.Groups["variable"].Value});";
+            });
+            Console.WriteLine($"Merged: {mergedResult}");
+            
+            Console.WriteLine($"Match: {result2 == mergedResult}");
+            Console.WriteLine();
+        }
+    }
+}

--- a/experiments/SimpleTest/Program.cs
+++ b/experiments/SimpleTest/Program.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+public class Program
+{
+    public static void Main() 
+    {
+        // Test the exact regex pattern from the updated code
+        var mergedRule = new Regex(@"cout << (?<content>(?:""[^""\r\n]+"")|(?:[_a-zA-Z0-9]+));");
+        
+        string[] testCases = {
+            "cout << \"Hello World\";",
+            "cout << variable;",
+            "cout << \"text with spaces\";", 
+            "cout << myVar;",
+            "int main() { cout << \"Hello\"; cout << x; }"
+        };
+        
+        Console.WriteLine("Testing merged cout rule:");
+        Console.WriteLine("========================");
+        
+        foreach (string test in testCases) 
+        {
+            string result = mergedRule.Replace(test, "System.out.print(${content});");
+            Console.WriteLine($"Input:  {test}");
+            Console.WriteLine($"Output: {result}");
+            Console.WriteLine();
+        }
+    }
+}

--- a/experiments/SimpleTest/SimpleTest.csproj
+++ b/experiments/SimpleTest/SimpleTest.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/experiments/SubstitutionTest/Program.cs
+++ b/experiments/SubstitutionTest/Program.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+class Program 
+{
+    static void Main() 
+    {
+        // Test cases
+        string[] testCases = {
+            "cout << \"Hello World\";",
+            "cout << variable;", 
+            "cout << \"text with spaces\";",
+            "cout << myVar;"
+        };
+        
+        // Single regex that captures everything after << 
+        // and uses a simple string replacement
+        var mergedRule = new Regex(@"cout << (?<content>(?:""[^""\r\n]+"")|(?:[_a-zA-Z0-9]+));");
+        
+        Console.WriteLine("Testing simple string replacement approach:");
+        Console.WriteLine("==========================================");
+        
+        foreach (string test in testCases) 
+        {
+            Console.WriteLine($"Input: {test}");
+            
+            // Simple string replacement - just substitute cout << with System.out.print(
+            string result = mergedRule.Replace(test, "System.out.print(${content});");
+            Console.WriteLine($"Result: {result}");
+            Console.WriteLine();
+        }
+        
+        Console.WriteLine("This produces the correct Java output format!");
+    }
+}

--- a/experiments/SubstitutionTest/SubstitutionTest.csproj
+++ b/experiments/SubstitutionTest/SubstitutionTest.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/experiments/simple_test.cs
+++ b/experiments/simple_test.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Text.RegularExpressions;
+
+public class SimpleTest 
+{
+    public static void Main() 
+    {
+        // Test the exact regex pattern from the updated code
+        var mergedRule = new Regex(@"cout << (?<content>(?:""[^""\r\n]+"")|(?:[_a-zA-Z0-9]+));");
+        
+        string[] testCases = {
+            "cout << \"Hello World\";",
+            "cout << variable;",
+            "cout << \"text with spaces\";", 
+            "cout << myVar;",
+            "int main() { cout << \"Hello\"; cout << x; }"
+        };
+        
+        Console.WriteLine("Testing merged cout rule:");
+        Console.WriteLine("========================");
+        
+        foreach (string test in testCases) 
+        {
+            string result = mergedRule.Replace(test, "System.out.print(${content});");
+            Console.WriteLine($"Input:  {test}");
+            Console.WriteLine($"Output: {result}");
+            Console.WriteLine();
+        }
+    }
+}

--- a/experiments/test_cout_merge.cs
+++ b/experiments/test_cout_merge.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Text.RegularExpressions;
+
+class TestCoutMerge 
+{
+    static void Main() 
+    {
+        // Test cases
+        string[] testCases = {
+            "cout << \"Hello World\";",
+            "cout << variable;", 
+            "cout << \"text with spaces\";",
+            "cout << myVar;",
+            "cout << \"multi word text\";",
+            "cout << anotherVariable;"
+        };
+        
+        // Original separate rules
+        var rule1 = new Regex(@"cout << ""(?<text>[^""\r\n]+)"";");
+        var rule2 = new Regex(@"cout << (?<variable>[_a-zA-Z0-9]+);");
+        
+        // Proposed merged rule - handles both quoted strings and variables
+        var mergedRule = new Regex(@"cout << (?:""(?<text>[^""\r\n]+)""|(?<variable>[_a-zA-Z0-9]+));");
+        
+        Console.WriteLine("Testing original rules vs merged rule:");
+        Console.WriteLine("=====================================");
+        
+        foreach (string test in testCases) 
+        {
+            Console.WriteLine($"Input: {test}");
+            
+            // Test original rules
+            string result1 = rule1.Replace(test, "System.out.print(\"${text}\");");
+            string result2 = rule2.Replace(result1, "System.out.print(${variable});");
+            Console.WriteLine($"Original: {result2}");
+            
+            // Test merged rule
+            string mergedResult = mergedRule.Replace(test, m => {
+                if (m.Groups["text"].Success)
+                    return $"System.out.print(\"{m.Groups["text"].Value}\");";
+                else
+                    return $"System.out.print({m.Groups["variable"].Value});";
+            });
+            Console.WriteLine($"Merged: {mergedResult}");
+            
+            Console.WriteLine($"Match: {result2 == mergedResult}");
+            Console.WriteLine();
+        }
+    }
+}

--- a/experiments/test_substitution_rule.cs
+++ b/experiments/test_substitution_rule.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Text.RegularExpressions;
+
+class TestSubstitutionRule 
+{
+    static void Main() 
+    {
+        // Test cases
+        string[] testCases = {
+            "cout << \"Hello World\";",
+            "cout << variable;", 
+            "cout << \"text with spaces\";",
+            "cout << myVar;"
+        };
+        
+        // Current separate rules approach
+        var rule1 = new Regex(@"cout << ""(?<text>[^""\r\n]+)"";");
+        var rule2 = new Regex(@"cout << (?<variable>[_a-zA-Z0-9]+);");
+        
+        // Option 1: Single regex with conditional groups
+        var mergedRule1 = new Regex(@"cout << (?:""(?<text>[^""\r\n]+)""|(?<variable>[_a-zA-Z0-9]+));");
+        
+        // Option 2: Single regex that captures everything after <<
+        var mergedRule2 = new Regex(@"cout << (?<content>(?:""[^""\r\n]+"")|(?:[_a-zA-Z0-9]+));");
+        
+        Console.WriteLine("Testing different merged rule approaches:");
+        Console.WriteLine("=======================================");
+        
+        foreach (string test in testCases) 
+        {
+            Console.WriteLine($"Input: {test}");
+            
+            // Original approach
+            string orig1 = rule1.Replace(test, "System.out.print(\"${text}\");");
+            string orig2 = rule2.Replace(orig1, "System.out.print(${variable});");
+            Console.WriteLine($"Original: {orig2}");
+            
+            // Option 2 - capture content and transform
+            string merged2 = mergedRule2.Replace(test, match => {
+                string content = match.Groups["content"].Value;
+                if (content.StartsWith("\"") && content.EndsWith("\""))
+                {
+                    // It's a quoted string, keep the quotes
+                    return $"System.out.print({content});";
+                }
+                else 
+                {
+                    // It's a variable, no quotes needed
+                    return $"System.out.print({content});";
+                }
+            });
+            Console.WriteLine($"Merged2: {merged2}");
+            
+            Console.WriteLine($"Match: {orig2 == merged2}");
+            Console.WriteLine();
+        }
+    }
+}

--- a/experiments/test_transformer.cs
+++ b/experiments/test_transformer.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+class TestTransformer 
+{
+    static void Main() 
+    {
+        // Load the transformer assembly 
+        var transformerPath = Path.Combine("..", "..", "RegularExpressions.Transformer.CppToJava", "bin", "Debug", "net8.0", "RegularExpressions.Transformer.CppToJava.dll");
+        
+        if (!File.Exists(transformerPath))
+        {
+            Console.WriteLine("Building transformer first...");
+            System.Diagnostics.Process.Start("dotnet", "build ../RegularExpressions.Transformer.CppToJava").WaitForExit();
+        }
+        
+        try 
+        {
+            var assembly = Assembly.LoadFrom(transformerPath);
+            var transformerType = assembly.GetType("Platform.RegularExpressions.Transformer.CppToJava.CppToJavaTransformer");
+            var transformer = Activator.CreateInstance(transformerType);
+            var transformMethod = transformerType.GetMethod("Transform");
+            
+            // Test cases for cout rules
+            string[] testCases = {
+                "cout << \"Hello World\";",
+                "cout << variable;",
+                "cout << \"multi word text\";",
+                "cout << myVar;"
+            };
+            
+            Console.WriteLine("Testing merged cout rule with actual transformer:");
+            Console.WriteLine("===============================================");
+            
+            foreach (string test in testCases) 
+            {
+                string result = (string)transformMethod.Invoke(transformer, new object[] { test });
+                Console.WriteLine($"Input:  {test}");
+                Console.WriteLine($"Output: {result}");
+                Console.WriteLine();
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error: {ex.Message}");
+            Console.WriteLine("Building and trying again...");
+            
+            // Build the project
+            var buildProcess = System.Diagnostics.Process.Start("dotnet", "build ../RegularExpressions.Transformer.CppToJava");
+            buildProcess.WaitForExit();
+            
+            Console.WriteLine("Build completed. Please run the test again.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Merged two separate regex rules for `cout` transformations into a single rule
- Previously had separate rules for `cout << "text";` and `cout << variable;`
- Now uses one unified regex pattern that handles both quoted strings and variables
- Reduces code duplication and improves maintainability

## Technical Details
**Before:**
```csharp
// cout << "text";
// System.out.print("text");
(new Regex(@"cout << ""(?<text>[^""\r\n]+)"";"), "System.out.print(\"${text}\");", null, 0),
// cout << text;
// System.out.print(text);
(new Regex(@"cout << (?<variable>[_a-zA-Z0-9]+);"), "System.out.print(${variable});", null, 0),
```

**After:**
```csharp
// cout << "text"; or cout << variable;
// System.out.print("text"); or System.out.print(variable);
(new Regex(@"cout << (?<content>(?:""[^""\r\n]+"")|(?:[_a-zA-Z0-9]+));"), "System.out.print(${content});", null, 0),
```

## Test Results
Verified that the merged rule produces identical output for all test cases:
- `cout << "Hello World";` → `System.out.print("Hello World");`
- `cout << variable;` → `System.out.print(variable);`
- Multiple cout statements in one line work correctly

## Changes Made
- **File:** `RegularExpressions.Transformer.CppToJava/CppToJavaTransformer.cs`
- **Lines:** 44-49 (now consolidated into lines 44-46)
- **Reduction:** 6 lines → 3 lines (-50% line reduction)

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #1